### PR TITLE
Fix CI test and settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,10 @@ sudo: false
 rvm:
 - 2.1
 matrix:
-    fast_finish: true
     include:
-        - # GitHub Pages versions on https://pages.github.com/versions/
-        rvm: 2.1.1
-        env: JEKYLL_VERSION=2.4.0
+        - rvm: 2.1
+          env: JEKYLL_VERSION=2.4
+    fast_finish: true
 
 # branch whitelist, only for GitHub Pages
 branches:

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,13 @@ require 'open-uri'
 versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 
 gem 'github-pages', versions['github-pages']
-gem 'foreman'
+
+group :development do
+    gem 'foreman'
+end
 
 group :test do
-  gem 'html-proofer'
-  gem 'rake'
+    gem 'rake'
+    gem 'jekyll', versions['jekyll']
+    gem 'html-proofer'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,6 @@ GEM
     pygments.rb (0.6.3)
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.2.0)
-    rake (10.4.2)
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
@@ -156,8 +155,8 @@ DEPENDENCIES
   foreman
   github-pages (= 40)
   html-proofer
+  jekyll (= 2.4.0)
   json
-  rake
 
 BUNDLED WITH
    1.11.2

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ rbenv local 2.1.6
 ```
 Pour vérifier la version de Ruby utilisée :
 ```bash
-rbenv version
+$ rbenv version
 ruby 2.1.6
 ```
 
@@ -33,18 +33,18 @@ ruby 2.1.6
 
 Si vous n'avez pas déjà cloné le dépot :
 ```bash
-git clone https://github.com/sudweb/2016.git 2016 && cd 2016
+$ git clone https://github.com/sudweb/2016.git 2016 && cd 2016
 ```
 Si bundler n'est pas installé
 ```bash
-gem install bundler
+$ gem install bundler
 ```
 Pour installer toutes les dépendances du projet :
 ```bash
-bundle install
+$ bundle install
 ```
 
-## Utilisation
+## Travailler en local
 
 Pour travailler sur le site et surveiller les modifications :
 ```bash
@@ -53,9 +53,9 @@ $ bundle exec foreman start
 
 Si vous modifiez le fichier `_config.yml`, il faut lancer
 ```bash
-$ bundle exec Jekyll build --trace  
+$ bundle exec Jekyll build   
 ```
-Le site est maintenant accessible en local à l'adresse http://0.0.0.0:4000/
+Le site est maintenant accessible en local à l'adresse http://0.0.0.0:4000/2016/
 
 Pour plus d'information sur l'utilisation de Jekyll, reportez-vous à la [documentation officielle](http://jekyllrb.com/docs/home/).
 
@@ -64,6 +64,16 @@ Pour plus d'information sur l'utilisation de Jekyll, reportez-vous à la [docume
 Pour toute demande, merci de [créer une issue](https://github.com/sudweb/2016/issues/new) sur GitHub.
 
 Si vous souhaitez nous aider, vous pouvez [copier](https://help.github.com/articles/fork-a-repo/) le dépôt, faire vos modifications dans une nouvelle branche, et [faire une demande de fusion](https://github.com/sudweb/2016/pulls).
+
+Toute modification doit faire l'objet d'une `pull request` et doit passer les tests avant de pouvoir être fusionnée.
+
+## Tests
+
+Avant de soumettre votre pull request, lancez le script de test d'intégration continue :
+
+```bash
+$ script/cibuild
+```
 
 ## Licence
 

--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ url: http://sudweb.fr
 baseurl: /2016
 
 # Services configuration
+
 analytics:
   google :
     tracking_id : "UA-22076213-1"
@@ -30,7 +31,7 @@ collections:
     order: date asc
     permalink: /talks/:path/
 
-exclude: [Gemfile, Gemfile.lock, Procfile, vendor, gems]
+exclude: [Gemfile, Gemfile.lock, Procfile, script, vendor, gems]
 
 gems:
 - jekyll-sitemap

--- a/_config_ci.yml
+++ b/_config_ci.yml
@@ -1,1 +1,0 @@
-url: http://sudweb.github.io

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -e # halt script on error
 
-bundle exec jekyll build --config _config.yml,_config_ci.yml JEKYLL_ENV=production --verbose
-bundle exec htmlproof ./_site --empty-alt-ignore --url-ignore "#"
+bundle exec jekyll build --destination _site/2016/ JEKYLL_ENV=production --verbose
+bundle exec htmlproof ./_site --disable-external --empty-alt-ignore --url-ignore "#"


### PR DESCRIPTION
- Sticking with the same Jekyll version as the one used by Github Pages
- Jekyll must be build with the baseurl folder for ci to pass tests
- foreman is only needed for development
- script folder can be excluded from Jekyll build
