### PR TITLE
Fix scrollbars appearing on hover animation

### DIFF
--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -2,6 +2,7 @@
 
 .masthead {
     text-align: center;
+    overflow: hidden;
 
     h1 {
         margin-bottom: 0;


### PR DESCRIPTION
The masthead logo animation on hover causes it to grow wider than the viewport, causing scrollbars to appear.
