### PR TITLE
Conseiller d'utiliser `rbenv install` sans argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,26 +7,13 @@ Site internet du cycle de conférences annuel Sud Web, dont la 6e édition aura 
 [http://sudweb.fr/2016](http://sudweb.fr/2016)
 
 ## Pré-requis
-Le site est géré via [Github Pages](https://pages.github.com/) et [Jekyll](http://jekyllrb.com/) et nécessite Ruby 2.1.x
+Le site est géré via [Github Pages](https://pages.github.com/) et [Jekyll](http://jekyllrb.com/) et nécessite Ruby 2.1.x (voir `.ruby-version`)
 
 Nous vous recommandons de gérer l'installation de Ruby via [rbenv](http://rbenv.org/).
 
 Sous Mac OS X, vous pouvez utiliser [Homebrew](http://brew.sh/) pour cela
 ```bash
 $ brew install rbenv ruby-build
-```
-Pour installer la version de Ruby nécéssaire au projet (fichier `.ruby-version`)
-```bash
-$ rbenv install
-```
-Pour définir ou changer la version utilisée localement pour l'application :
-```bash
-$ rbenv local 2.1.6
-```
-Pour vérifier la version de Ruby utilisée :
-```bash
-$ rbenv version
-ruby 2.1.6
 ```
 
 ## Installation
@@ -42,6 +29,10 @@ $ gem install bundler
 Pour installer toutes les dépendances du projet :
 ```bash
 $ bundle install
+```
+Pour installer la bonne version de Ruby
+```bash
+$ rbenv install
 ```
 
 ## Travailler en local

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Sous Mac OS X, vous pouvez utiliser [Homebrew](http://brew.sh/) pour cela
 ```bash
 $ brew install rbenv ruby-build
 ```
-Pour installer la version 2.1.6 de Ruby
+Pour installer la version de Ruby nécéssaire au projet (fichier `.ruby-version`)
 ```bash
-$ rbenv install 2.1.6
+$ rbenv install
 ```
-Pour définir la version utilisée localement pour l'application:
+Pour définir ou changer la version utilisée localement pour l'application :
 ```bash
 $ rbenv local 2.1.6
 ```


### PR DESCRIPTION
### Quel problème cette PR corrige-t-elle ?

Dans le fichier README.md, les insctructions concernant les pré-requis indiquent la commande `rbenv install 2.1.6` alors que le projet dispose d'un fichier `.ruby-version` référençant la version 2.1.7.

En utilisant la commande `rbenv install` sans y préciser de numéro de version permet d'installer automatiquement celle du fichier `.ruby-version`.
### Quels sont les changement(s) apporté(s) ?
- _Voir le diff sera plus parlant et plus court._
### Qui devrait être prévenu de cette demande ?

@oncletom 
