### PR TITLE
Docker image for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM ruby
+
+RUN  curl -sL https://deb.nodesource.com/setup_5.x | bash -
+RUN  apt-get update
+RUN  apt-get install -y --no-install-recommends build-essential git nodejs \
+     && apt-get clean \
+     && rm -rf /var/lib/apt/lists/
+
+RUN  gem install bundler --no-rdoc --no-ri
+
+RUN  git clone https://github.com/rbenv/rbenv.git ~/.rbenv --depth=5 && cd ~/.rbenv && src/configure && make -C src \
+     && git clone --depth=5 https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
+
+RUN  echo "eval \"\$(rbenv init -)\"" >> $HOME/.profile
+RUN  echo "eval \"\$(rbenv init -)\"" >> $HOME/.bashrc
+
+ENV  PATH $PATH:/root/.rbenv/bin
+RUN  eval "$(rbenv init -)"
+COPY .ruby-version ./
+RUN  rbenv install
+COPY Gemfil* ./
+RUN  bundle install
+
+VOLUME /sudweb
+ENV LANG C.UTF-8
+
+EXPOSE 4000
+
+ENTRYPOINT  cd /sudweb && bundle exec foreman start

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ ENV LANG C.UTF-8
 
 EXPOSE 4000
 
-ENTRYPOINT  cd /sudweb && bundle exec foreman start
+ENTRYPOINT  tail -n1 /etc/hosts && cd /sudweb && bundle exec foreman start

--- a/README.md
+++ b/README.md
@@ -50,6 +50,23 @@ Le site est maintenant accessible en local à l'adresse http://0.0.0.0:4000/2016
 
 Pour plus d'information sur l'utilisation de Jekyll, reportez-vous à la [documentation officielle](http://jekyllrb.com/docs/home/).
 
+### Aternative par Docker
+
+Plutôt que d'installer les outils en local, il est possible d'utiliser [Docker](http://www.docker.com/) pour créer un conteneur qui en disposera. Après avoir cloné le dépôt, depuis sa racine, utiliser les commandes suivantes :
+
+**Pour créer l'image :**
+```bash
+$ docker build -t sudweb2016 .
+```
+_(La création initiale de l'image peur durer plusieurs minutes)_
+
+**Pour lancer le conteneur :**
+```bash
+$ docker run --rm -p 4000:4000 -v $(pwd):/sudweb -ti sudweb
+```
+* Sous linux, Jekyll sera accessible sur http://localhost:4000/2016/.
+* Sous OSX, il faudra remplacer `localhost` par l'IP du Docker host.
+
 ## Styleguide et notes d'intégration
 
 * [Styleguide](http://sudweb.fr/2016/styleguide/)

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,3 +1,4 @@
 url: http://0.0.0.0:4000
+host: 0.0.0.0
 sass:
   style: uncompressed


### PR DESCRIPTION
Première proposition pour un Dockerfile de développement.

**Générer l'image :**

``` bash
$ docker build -t sudweb .
```

**Lancer le conteneur**

``` bash
$ docker run --rm -p 4000 -v $(pwd):/sudweb -u `stat -c "%u:%g" .` -ti sudweb
```

La génération de l'image est relativement longue, mais le lancement du conteneur est instantané.

Il y a très certainement un paquet d'amélioration à apporter _(Je ne suis qu'un débutant en docker, c'est mon premier 'vrai' Dockerfile)_, entre autres en allégeant l'image...
_Note : J'ai résolu un souci de locale en tombant sur cet article https://oncletom.io/2015/docker-encoding/ ;)_

Mais il reste un souci majeur : je ne parviens pas encore à accéder au dispositif en http...

Donc il vaut mieux ne pas fusionner cette PR tout de suite, je l'ai initié surtout pour pouvoir échanger.

@oncletom un avis ?
