### PR TITLE
Disable navigation links that point to the current page

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -13,7 +13,7 @@
     </a>
     {% for link in site.data.navigation.primary %}
     {% assign class = nil %}
-    {% if page.url contains link.url %}
+    {% if page.url == link.url %}
       {% assign class = 'is--active' %}
     {% endif %}
     <a href="{{ site.baseurl }}{{ link.url }}" class="{{ class }}" data-event-category="cta" data-event-action="click" data-event-label="navigation-{{ link.title }}">{{ link.title }}</a>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -12,11 +12,11 @@
       </svg>
     </a>
     {% for link in site.data.navigation.primary %}
-    {% assign class = nil %}
     {% if page.url == link.url %}
-      {% assign class = 'is--active' %}
+    <span class="nav is--active">{{ link.title }}</span>
+    {% else %}
+    <a href="{{ site.baseurl }}{{ link.url }}" class="nav" data-event-category="cta" data-event-action="click" data-event-label="navigation-{{ link.title }}">{{ link.title }}</a>
     {% endif %}
-    <a href="{{ site.baseurl }}{{ link.url }}" class="{{ class }}" data-event-category="cta" data-event-action="click" data-event-label="navigation-{{ link.title }}">{{ link.title }}</a>
     {% endfor %}
   </div>
 </nav>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -4,11 +4,13 @@
 
 .main-nav {
 	background: $nav-bg;
-	a {
+	
+	.logo,
+	.nav {
 		display: inline-block;
 		vertical-align: middle;
 	}
-	a:not(.logo) {
+	.nav {
 		position: relative; padding: 3%; overflow: hidden;
 		font: $tiny-title-size $title-font-family; color: $nav-color; text-decoration: none;
 		&::before {
@@ -18,8 +20,9 @@
 			content: ''; opacity: 0;
 			transition: $default-delay $default-timing-function;
 		}
-		&:hover,
-		&:focus {
+		&.is--active,
+		&:link:hover,
+		&:link:focus {
 			&::before {
 				transform: translateY(0) translateX(-50%) rotate(-45deg) skew(10deg,10deg);
 				opacity: 1;


### PR DESCRIPTION
### Quels sont les changement(s) apporté(s) ?
- the `is--active` class is now correctly set (`if page.url contains link.url` didn't work, at least locally)
- the current navigation item is now a `span` instead of an `a`
- the styles have been updated to show the `is--active` indicator for the current page
### Qui devrait être prévenu de cette demande ?

@sudweb/thym
