### PR TITLE
Dedupe display of attendees with multiple tickets

### DIFF
--- a/participants.html
+++ b/participants.html
@@ -20,7 +20,7 @@ permalink: /participants/
   <article>
     <section class="white-section">
       <div class="grid-4 text-center">
-        {% assign attendees = site.data.attendees | sort: "date" | reverse %}
+        {% assign attendees = site.data.attendees | sort: "date" | reverse | uniq: "name" %}
         {% for attendee in attendees %}
         {% if attendee.ticket_type == '701385'%}{% continue %}{% endif %}
         <div>


### PR DESCRIPTION
### Quel problème cette PR corrige-t-elle ?

Un participant ayant plusieurs tickets apparait plusieurs fois dans la liste.
### Quels sont les changement(s) apporté(s) ?
- Ajout d'un filtre pour dédoublonner le tableau de rendu des participants.
### Qui devrait être prévenu de cette demande ?

@sudweb/thym
