### PR TITLE
Allow using custom avatar URL

### DIFF
--- a/_data/attendees.json
+++ b/_data/attendees.json
@@ -717,6 +717,7 @@
 "name": "Benjamin MARGUIN",
 "twitter": "mab_",
 "code_postal": "31300",
+"avatar": "https://secure.gravatar.com/avatar/32377cce82ea3738a448093451f7fe51",
 "email": "32377cce82ea3738a448093451f7fe51"
 },
 {
@@ -852,6 +853,7 @@
 "name": "Benjamin MARGUIN",
 "twitter": "mab_",
 "code_postal": "31300",
+"avatar": "https://secure.gravatar.com/avatar/32377cce82ea3738a448093451f7fe51",
 "email": "32377cce82ea3738a448093451f7fe51"
 },
 {
@@ -960,6 +962,7 @@
 "name": "Benjamin MARGUIN",
 "twitter": "mab_",
 "code_postal": "31300",
+"avatar": "https://secure.gravatar.com/avatar/32377cce82ea3738a448093451f7fe51",
 "email": "32377cce82ea3738a448093451f7fe51"
 },
 {

--- a/participants.html
+++ b/participants.html
@@ -34,9 +34,9 @@ permalink: /participants/
         {% endcomment %}
 
         <div class="attendee {% if attendee.ticket_type == '667251' %} golden-ticket{% endif %}">
-          {% if attendee.title == 'Mme' %}
-          <img class="attendee-avatar" src="https://secure.gravatar.com/avatar/{{ attendee.email }}?d={{ super-woman | prepend: site.baseurl | prepend: site.url | cgi_escape }}" alt="Superwoman">
-          {% else %}
+          {% if attendee.avatar %}
+          <img class="attendee-avatar" src="{{ attendee.avatar }}" alt="SuperAvatar">
+          {% else if attendee.title == 'Mme' %}
           <img class="attendee-avatar" src="https://secure.gravatar.com/avatar/{{ attendee.email }}?d={{ default-avatar | prepend: site.baseurl | prepend: site.url | cgi_escape }}" alt="Superman">
           {% endif %}
           <br>


### PR DESCRIPTION
_Je comprendrais très bien que la fonctionnalité puisse être refusée, surtout qu'il est simple de changer l'image associée à une adresse sur Gravatar. Mais étant donné qu'elle était simple à développer, elle a au moins le mérite d'être faite._
### Quels sont les changement(s) apporté(s) ?
- Si une clé `avatar` existe pour un objet participant dans `attendees.json`, son contenu est utilisé comme avatar au lieu de l'url Gravatar construite avec le hash de l'adresse mail.

_**NB** : L'exemple fait sur `attendees.json` utilise l'url de Gravatar, ça peut prêter à confusion. Bien sûr, elle pourrait être complètement différente._

Ça fait suite à la demande #96.
